### PR TITLE
Naming and doc fixes to auth handlers

### DIFF
--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -324,12 +324,3 @@ NAMESPACES = frozenset(NAMESPACES_MAP.values())
 # Indicates whether or not external plugins (i.e., plugins that aren't shipped
 # with conda) are enabled
 NO_PLUGINS = False
-
-#: Name we use to identify the auth backend in ``channel_settings``
-AUTH_CHANNEL_SETTINGS_NAME = "auth"
-
-#: Name we use to identify the username for authentication in ``channel_settings``
-USERNAME_CHANNEL_SETTINGS_NAME = "username"
-
-#: Name we use to identify the channel name in ``channel_settings``
-CHANNEL_CHANNEL_SETTINGS_NAME = "channel"

--- a/conda/plugins/__init__.py
+++ b/conda/plugins/__init__.py
@@ -27,7 +27,7 @@ as well as conda's internal implementations of plugins.
 
 from .hookspec import hookimpl  # noqa: F401
 from .types import (  # noqa: F401
-    CondaAuth,
+    CondaAuthHandler,
     CondaPostCommand,
     CondaPreCommand,
     CondaSolver,

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -203,16 +203,15 @@ class CondaPluginManager(pluggy.PluginManager):
 
         return backend
 
-    def get_auth_backend(self, name: str) -> type[AuthBase]:
+    def get_auth_handler(self, name: str) -> type[AuthBase]:
         """
-        Get the auth class with the given name (or fall back to the
-        default CondaSession class).
+        Get the auth handler with the given name or None
         """
-        auth_backends = self.get_hook_results("auth")
-        matches = tuple(item for item in auth_backends if item.name == name)
+        auth_handlers = self.get_hook_results("auth_handlers")
+        matches = tuple(item for item in auth_handlers if item.name == name.strip())
 
         if len(matches) > 0:
-            return matches[0].auth_class
+            return matches[0].handler
 
     def invoke_pre_commands(self, command: str) -> None:
         """

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -106,14 +106,15 @@ class CondaPostCommand(NamedTuple):
     run_for: set[str]
 
 
-class CondaAuth(NamedTuple):
+class CondaAuthHandler(NamedTuple):
     """
     Return type to use when the defining the conda fetch hook.
 
     :param name: Name (e.g., ``basic-auth``). This name should be unique
                  and only one may be registered at a time.
-    :param auth_class: Type that will be used as the authentication on HTTP/HTTPS requests
+    :param handler: Type that will be used as the authentication handler
+                    during network requests.
     """
 
     name: str
-    auth_class: type[AuthBase]
+    handler: type[AuthBase]

--- a/tests/gateways/test_connection.py
+++ b/tests/gateways/test_connection.py
@@ -125,7 +125,7 @@ def test_session_manager_returns_default():
     url = "https://localhost/test"
     session_obj = session_manager(url)
 
-    assert type(session_obj) == CondaSession
+    assert type(session_obj) is CondaSession
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly we would appreciate it if you follow this template. -->

### Description

Just a few naming fixes mostly, to make sure we're following the precedence from requests and prepare a future additional plugin hook about requests' transport adapters. On https://requests.readthedocs.io/en/latest/user/authentication/ it speaks about "authentication handlers".

More comments inline..

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/master/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC:
       - Contributing docs: https://github.com/conda/conda/blob/master/CONTRIBUTING.md -->
