### PR TITLE
Route bundled preview subcommands through plugin policy

### DIFF
--- a/conda/_preview/__init__.py
+++ b/conda/_preview/__init__.py
@@ -14,9 +14,10 @@ Conventions
   - ``PREVIEW_LABEL: str`` — the kebab-case label users put in ``context.preview``.
   - ``register(context)`` — called once after the final ``context.__init__()`` in
     ``main_subshell()`` when this preview is enabled.
-- Each preview may mirror conda's ``cli/`` module structure under its own ``cli/``
-  subdirectory. Modules there are discovered dynamically by ``do_call()`` and require
-  no registration — adding ``cli/main_update.py`` is sufficient.
+- Preview command implementations should use conda's plugin framework. For
+  subcommands, expose ``conda_subcommands`` hooks and register them through
+  ``conda.plugins.previews``. Built-in command overrides are only allowed for
+  bundled preview subcommands routed through conda's preview plugin.
 
 Graduation path
 ---------------

--- a/conda/_preview/env_setup/cli/main_create.py
+++ b/conda/_preview/env_setup/cli/main_create.py
@@ -11,24 +11,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ....base.context import context
-from ....cli.helpers import (
-    add_output_and_prompt_options,
-    add_parser_help,
-    add_parser_prefix,
-)
 from ....exceptions import OperationNotAllowed
 from ....plugins import hookimpl
 from ....plugins.types import CondaSubcommand
 
 if TYPE_CHECKING:
-    from argparse import ArgumentParser, Namespace
-
-
-def configure_parser(parser: ArgumentParser) -> None:
-    add_parser_help(parser)
-    add_parser_prefix(parser)
-    add_output_and_prompt_options(parser)
+    from argparse import Namespace
+    from collections.abc import Iterable
 
 
 def execute(args: Namespace) -> int:
@@ -38,11 +27,9 @@ def execute(args: Namespace) -> int:
 
 
 @hookimpl
-def conda_subcommands() -> None:
-    if "env-setup" in context.preview:
-        yield CondaSubcommand(
-            name="create",
-            summary="Create a new conda environment.",
-            action=execute,
-            configure_parser=configure_parser,
-        )
+def conda_subcommands() -> Iterable[CondaSubcommand]:
+    yield CondaSubcommand(
+        name="create",
+        summary="Create a new conda environment.",
+        action=execute,
+    )

--- a/conda/_preview/env_setup/cli/main_install.py
+++ b/conda/_preview/env_setup/cli/main_install.py
@@ -11,18 +11,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ....base.context import context
-from ....cli.helpers import (
-    add_output_and_prompt_options,
-    add_parser_help,
-    add_parser_prefix,
-)
 from ....exceptions import OperationNotAllowed
 from ....plugins import hookimpl
 from ....plugins.types import CondaSubcommand
 
 if TYPE_CHECKING:
-    from argparse import ArgumentParser, Namespace
+    from argparse import Namespace
+    from collections.abc import Iterable
 
 
 def execute(args: Namespace) -> int:
@@ -31,18 +26,10 @@ def execute(args: Namespace) -> int:
     )
 
 
-def configure_parser(parser: ArgumentParser) -> None:
-    add_parser_help(parser)
-    add_parser_prefix(parser)
-    add_output_and_prompt_options(parser)
-
-
 @hookimpl
-def conda_subcommands() -> None:
-    if "env-setup" in context.preview:
-        yield CondaSubcommand(
-            name="install",
-            summary="Install packages to a conda environment.",
-            action=execute,
-            configure_parser=configure_parser,
-        )
+def conda_subcommands() -> Iterable[CondaSubcommand]:
+    yield CondaSubcommand(
+        name="install",
+        summary="Install packages to a conda environment.",
+        action=execute,
+    )

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -14,16 +14,15 @@ from argparse import (
 from argparse import ArgumentParser as ArgumentParserBase
 from functools import partial
 from importlib import import_module
-from inspect import getmodule
 from logging import getLogger
 from subprocess import Popen
-from typing import TYPE_CHECKING
 
 from .. import __version__
 from ..auxlib.ish import dals
 from ..base.context import context, sys_rc_path, user_rc_path
 from ..common.compat import isiterable, on_win
 from ..common.constants import NULL
+from ..plugins.previews import is_preview_subcommand
 from .actions import ExtendConstAction, NullCountAction  # noqa: F401
 from .helpers import (  # noqa: F401
     add_output_and_prompt_options,
@@ -66,9 +65,6 @@ from .main_rename import configure_parser as configure_parser_rename
 from .main_run import configure_parser as configure_parser_run
 from .main_search import configure_parser as configure_parser_search
 from .main_update import configure_parser as configure_parser_update
-
-if TYPE_CHECKING:
-    from ..plugins.types import CondaSubcommand
 
 log = getLogger(__name__)
 
@@ -173,11 +169,10 @@ def generate_parser(**kwargs) -> ArgumentParser:
     preview_plugin_commands = {
         name
         for name, plugin_subcommand in context.plugin_manager.get_subcommands().items()
-        if _is_preview_command(plugin_subcommand)
+        if is_preview_subcommand(plugin_subcommand)
     }
 
-    # We only register if it's not being overriden by something in the
-    # `conda._preview` module
+    # We only register built-ins that are not overridden by bundled previews.
     for builtin, config_func in BUILTIN_COMMAND_PARSERS.items():
         if builtin not in preview_plugin_commands:
             config_func(sub_parsers)
@@ -296,15 +291,6 @@ def _exec_unix(executable_args, env_vars):
     os.execvpe(executable_args[0], executable_args, env_vars)
 
 
-def _is_preview_command(plugin_subcommand: CondaSubcommand) -> bool:
-    """
-    Determine whether this plugin subcommand is a preview command.
-    """
-    module_name = getmodule(plugin_subcommand.action).__name__
-
-    return module_name.startswith("conda._preview")
-
-
 def configure_parser_plugins(sub_parsers) -> None:
     """
     For each of the provided plugin-based subcommands, we'll create
@@ -316,7 +302,17 @@ def configure_parser_plugins(sub_parsers) -> None:
     for name, plugin_subcommand in plugin_subcommands.items():
         # if the name of the plugin-based subcommand overlaps a built-in
         # subcommand, we print an error
-        if name in BUILTIN_COMMANDS and not _is_preview_command(plugin_subcommand):
+        if name in BUILTIN_COMMANDS:
+            if (
+                is_preview_subcommand(plugin_subcommand)
+                and name in BUILTIN_COMMAND_PARSERS
+            ):
+                parser = BUILTIN_COMMAND_PARSERS[name](sub_parsers)
+                if plugin_subcommand.configure_parser:
+                    plugin_subcommand.configure_parser(parser)
+                parser.set_defaults(_plugin_subcommand=plugin_subcommand)
+                continue
+
             log.error(
                 dals(
                     f"""

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -51,10 +51,14 @@ def main_subshell(*args, post_parse_hook=None, **kwargs):
     # Unrecognized labels are silently skipped so typos don't crash the CLI.
     for label in context.preview:
         package = label.replace("-", "_")
+        module_name = f"conda._preview.{package}"
         try:
-            mod = import_module(f"conda._preview.{package}")
-        except ModuleNotFoundError:
-            continue
+            mod = import_module(module_name)
+        except ModuleNotFoundError as err:
+            # Ignore unknown preview labels, but surface missing imports inside previews.
+            if err.name == module_name:
+                continue
+            raise
         mod.register(context)
 
     # used with main_pip.py

--- a/conda/plugins/previews.py
+++ b/conda/plugins/previews.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""Built-in plugin hooks for opt-in preview features."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..base.context import context
+from . import hookimpl
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
+    from .types import CondaSubcommand
+
+PREVIEW_PLUGIN_NAME = __name__
+
+
+@hookimpl
+def conda_subcommands():
+    from .._preview.env_setup import PREVIEW_LABEL as ENV_SETUP_PREVIEW_LABEL
+    from .._preview.env_setup.cli import main_create, main_install
+
+    yield from _preview_subcommands(
+        ENV_SETUP_PREVIEW_LABEL,
+        main_create.conda_subcommands,
+        main_install.conda_subcommands,
+    )
+
+
+def _preview_subcommands(
+    label: str,
+    *subcommand_hooks: Callable[[], Iterable[CondaSubcommand]],
+) -> Iterable[CondaSubcommand]:
+    if not context.preview_enabled(label):
+        return
+
+    for subcommand_hook in subcommand_hooks:
+        yield from subcommand_hook()
+
+
+def is_preview_subcommand(plugin_subcommand: CondaSubcommand) -> bool:
+    """
+    Determine whether this plugin subcommand is a bundled preview command.
+    """
+    plugin_name = getattr(getattr(plugin_subcommand, "impl", None), "plugin_name", "")
+
+    return plugin_name == PREVIEW_PLUGIN_NAME

--- a/conda/plugins/subcommands/__init__.py
+++ b/conda/plugins/subcommands/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-from ..._preview.env_setup.cli import main_create, main_install
+from .. import previews
 from . import doctor
 
-plugins = [doctor, main_create, main_install]
+plugins = [doctor, previews]

--- a/docs/source/dev-guide/previews.md
+++ b/docs/source/dev-guide/previews.md
@@ -11,9 +11,9 @@ love, we'll integrate the preview as a core component of conda.
 The previews themselves reside in the {mod}`conda._preview` module. Within
 this module, you'll find various feature modules that we're experimenting
 with (e.g. {mod}`conda._preview.env_setup` contains a set of new commands overriding
-the traditional environment creation and management process). These feature modules
-mirror the top-level `conda` module so that when/if these features are taken
-out of experimentation, the updates can be more-or-less seamless.
+the traditional environment creation and management process). Preview modules
+can mirror the top-level `conda` module where that makes graduation easier, but
+CLI entry points should still be wired through conda's plugin framework.
 
 
 :::{warning}
@@ -38,3 +38,5 @@ preview:
    or as a collection of issues before creating a preview.
 2. When creating your own preview feature, please use snake-case for the module name and
    kebab-case for the name that appears in the configuration file.
+3. Preview subcommands should be exposed through `conda.plugins.previews`, which gates
+   bundled preview hook implementations with their matching preview label.

--- a/news/16011-add-preview-namespace-env-setup-stubs
+++ b/news/16011-add-preview-namespace-env-setup-stubs
@@ -2,5 +2,5 @@
 
 * Add `conda/_preview/` private namespace with `register(context)` convention for
   opt-in preview features; scaffold the first preview (`env-setup`) with non-operational
-  stubs for `conda create` and `conda install` wired into CLI dispatch via dynamic
-  module routing. (#16011)
+  stubs for `conda create` and `conda install` wired into CLI dispatch through
+  built-in plugin subcommand hooks. (#16011)

--- a/tests/_preview/env_setup/cli/test_main_create.py
+++ b/tests/_preview/env_setup/cli/test_main_create.py
@@ -37,12 +37,87 @@ def test_create_preview_enabled(
     monkeypatch.setenv("CONDA_PREVIEW", "env-setup")
 
     out, err, exc = conda_cli(
-        "create", "--name", "test-env", raises=OperationNotAllowed
+        "create", "--name", "test-env", "python", raises=OperationNotAllowed
     )
 
     assert exc.value is not None
     assert "env-setup" in str(exc.value)
     assert "conda create" in str(exc.value)
+
+
+def test_create_preview_enabled_with_no_plugins(
+    conda_cli: CondaCLIFixture,
+    monkeypatch,
+):
+    """Bundled preview subcommands remain available with --no-plugins."""
+    monkeypatch.setenv("CONDA_PREVIEW", "env-setup")
+
+    out, err, exc = conda_cli(
+        "--no-plugins",
+        "create",
+        "--name",
+        "test-env",
+        "python",
+        raises=OperationNotAllowed,
+    )
+
+    assert exc.value is not None
+    assert "env-setup" in str(exc.value)
+    assert "conda create" in str(exc.value)
+
+
+def test_create_preview_uses_builtin_parser_arguments(
+    conda_cli: CondaCLIFixture,
+    monkeypatch,
+):
+    """The preview stub accepts options from the built-in create parser."""
+    monkeypatch.setenv("CONDA_PREVIEW", "env-setup")
+
+    out, err, exc = conda_cli(
+        "create", "--clone", "base", "--name", "test-env", raises=OperationNotAllowed
+    )
+
+    assert exc.value is not None
+    assert "env-setup" in str(exc.value)
+    assert "conda create" in str(exc.value)
+
+
+def test_create_preview_can_extend_builtin_parser(
+    conda_cli: CondaCLIFixture,
+    monkeypatch,
+):
+    """A preview override can add options to the built-in command parser."""
+    from conda._preview.env_setup.cli import main_create
+    from conda.plugins.types import CondaSubcommand
+
+    def configure_parser(parser):
+        parser.add_argument("--preview-only-option", action="store_true")
+
+    def execute(args):
+        assert args.preview_only_option is True
+        raise OperationNotAllowed("preview-only option parsed")
+
+    def conda_subcommands():
+        yield CondaSubcommand(
+            name="create",
+            summary="Create a new conda environment.",
+            action=execute,
+            configure_parser=configure_parser,
+        )
+
+    monkeypatch.setattr(main_create, "conda_subcommands", conda_subcommands)
+    monkeypatch.setenv("CONDA_PREVIEW", "env-setup")
+
+    out, err, exc = conda_cli(
+        "create",
+        "--name",
+        "test-env",
+        "--preview-only-option",
+        raises=OperationNotAllowed,
+    )
+
+    assert exc.value is not None
+    assert "preview-only option parsed" in str(exc.value)
 
 
 def test_unknown_preview_label_no_crash(conda_cli: CondaCLIFixture, monkeypatch):

--- a/tests/_preview/env_setup/cli/test_main_install.py
+++ b/tests/_preview/env_setup/cli/test_main_install.py
@@ -35,7 +35,21 @@ def test_install_preview_enabled(
     """conda install with CONDA_PREVIEW=env-setup is routed to the stub."""
     monkeypatch.setenv("CONDA_PREVIEW", "env-setup")
 
-    out, err, exc = conda_cli("install", raises=OperationNotAllowed)
+    out, err, exc = conda_cli("install", "numpy", raises=OperationNotAllowed)
+
+    assert exc.value is not None
+    assert "env-setup" in str(exc.value)
+    assert "conda install" in str(exc.value)
+
+
+def test_install_preview_uses_builtin_parser_arguments(
+    conda_cli: CondaCLIFixture,
+    monkeypatch,
+):
+    """The preview stub accepts options from the built-in install parser."""
+    monkeypatch.setenv("CONDA_PREVIEW", "env-setup")
+
+    out, err, exc = conda_cli("install", "--revision", "1", raises=OperationNotAllowed)
 
     assert exc.value is not None
     assert "env-setup" in str(exc.value)


### PR DESCRIPTION
### Description

This is a stacked follow-up for conda/conda#16014. It replaces dynamic preview CLI routing with plugin-based handling for bundled preview subcommands while keeping the public plugin type surface unchanged.

The change adds `conda.plugins.previews` as the private policy point for built-in preview subcommands. That module gates bundled preview hook providers with `context.preview_enabled(label)`, and `conda_argparse.py` asks whether a subcommand came from that trusted preview plugin before allowing it to override a built-in command name. External plugin subcommands still cannot override built-ins.

For trusted preview overrides of built-in commands, argparse registers the existing built-in parser, optionally lets the preview subcommand extend that parser with `configure_parser`, and then redirects execution to the preview subcommand. That keeps the create/install parser surface in one place while allowing normal invocations such as `conda create -n test-env python`, `conda create --clone base -n test-env`, and `conda install --revision 1` to reach the non-operational preview stubs before raising `OperationNotAllowed`.

This also keeps bundled preview subcommands active under `--no-plugins` and preserves `ModuleNotFoundError`s raised from inside preview packages while still ignoring unknown preview labels.

### Verification

- `ruff check conda/cli/conda_argparse.py conda/cli/main.py conda/plugins/previews.py conda/_preview/env_setup/cli/main_create.py conda/_preview/env_setup/cli/main_install.py tests/_preview/env_setup/cli/test_main_create.py tests/_preview/env_setup/cli/test_main_install.py tests/plugins/test_subcommands.py`
- `ruff format --check conda/cli/conda_argparse.py conda/cli/main.py conda/plugins/previews.py conda/_preview/env_setup/cli/main_create.py conda/_preview/env_setup/cli/main_install.py tests/_preview/env_setup/cli/test_main_create.py tests/_preview/env_setup/cli/test_main_install.py tests/plugins/test_subcommands.py`
- `python -m pytest -W ignore::DeprecationWarning tests/_preview/env_setup/cli/test_main_create.py tests/_preview/env_setup/cli/test_main_install.py tests/_preview/env_setup/test_register.py tests/plugins/test_subcommands.py` (`40 passed`)
- Manual preview CLI probes for `create`, `create --clone`, `install`, `install --revision`, `--no-plugins`, and unknown preview labels.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?